### PR TITLE
Added API routes to access rpc commands

### DIFF
--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -137,11 +137,11 @@ function shouldCacheTransaction(tx) {
 }
 
 function getBlockchainInfo() {
-	return tryCacheThenRpcApi(miscCache, "getBlockchainInfo", 10000, rpcApi.getBlockchainInfo);
+	return tryCacheThenRpcApi(miscCache, "getBlockchainInfo", 1000, rpcApi.getBlockchainInfo);
 }
 
 function getChainAlgoStats() {
-	return tryCacheThenRpcApi(miscCache, "getChainAlgoStats", 10000, rpcApi.getChainAlgoStats);
+	return tryCacheThenRpcApi(miscCache, "getChainAlgoStats", 1000, rpcApi.getChainAlgoStats);
 }
 
 function getNetworkInfo() {

--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -1186,13 +1186,19 @@ router.get("/fun", function (req, res, next) {
     next();
 });
 
-router.get("/api/:rpcCmd/", function (req, res, next) {
-    coreApi.getPeerSummary().then(function (peerSummary) {
-        res.json("peers");
-        next();
-    }).catch(function (err) {
-        res.json("error");
-        next();
+router.get("/api/getblockchaininfo", function (req, res, next) {
+    coreApi.getBlockchainInfo().then(function(blockchainInfoResult) {
+        res.json(blockchainInfoResult);
+    }).catch(function(err) {
+        reject(err);
+    });
+});
+
+router.get("/api/getchainalgostats", function (req, res, next) {
+    coreApi.getChainAlgoStats().then(function(chainAlgoStats) {
+        res.json(chainAlgoStats);
+    }).catch(function(err) {
+        reject(err);
     });
 });
 


### PR DESCRIPTION
### Problem ###
Integration partners need access to RPC data without run a  node.

### Solution ###
Add API routes to match the RPC commands.

### Unit Testing Results ###
http://veil-explorer.codeofalltrades.com/api/getblockchaininfo
http://veil-explorer.codeofalltrades.com/api/getchainalgostats
